### PR TITLE
Made Travis only build branch pushes to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "3.6"
 
+branches:
+  only:
+    - master
+
 install:
   - pip install -r requirements.txt
   - pip install -r requirements.dev.txt


### PR DESCRIPTION
This should fix our Travis build status in the README. Currently Travis has not yet run a master build, I think this is because branch pushes were turned off in the web interface settings. In addition, I made Travis only run branch pushes to master. Since both branch pushes and pull requests are set to build in Travis settings, it will only build when we make a pull request and when we merge. If the pull request build passes, we know our push to master should pass.