### PR TITLE
Implement scanning for cloudfront plugin

### DIFF
--- a/oil/__init__.py
+++ b/oil/__init__.py
@@ -1,6 +1,1 @@
-class Oil():
-    def __init__(self, plugins, **kwargs):
-        self.plugins = plugins;
-
-    def scan(self):
-        pass
+from oil.oil import Oil

--- a/oil/barrels/aws/cloudfront.py
+++ b/oil/barrels/aws/cloudfront.py
@@ -4,12 +4,19 @@ class CloudFrontBarrel():
     def __init__(self, client=None):
         self.client = client or boto3.client('cloudfront')
 
+    def tap(self, call):
+        if call == 'list_distributions':
+            return self.list_distributions()
+        else:
+            # Should throw an error
+            return []
+
     def list_distributions(self):
         paginator = self.client.get_paginator('list_distributions')
         response_iterator = paginator.paginate()
         items_list = []
 
         for page in response_iterator:
-            items_list.extend(page['DistributionList']['Items'])
+            items_list.extend(page['DistributionList'].get('Items', []))
 
         return items_list

--- a/oil/oil.py
+++ b/oil/oil.py
@@ -1,0 +1,100 @@
+from oil.plugins.aws.cloudfront import TLSProtocolPlugin
+from oil.barrels.aws import CloudFrontBarrel
+
+
+class Oil():
+    def __init__(self, config={}):
+        """
+        TODO: Create sensible default configuration
+        """
+        self.config = config;
+        self.plugins = []
+        self.cached_api_data = {}
+        self.scan_data = {}
+
+        self._load_plugins()
+
+    def _load_plugins(self):
+        """
+        TODO: Make adding plugins more dynamic than a large if statement
+        """
+        aws_config = self.config.get('aws', {})
+        cloudfront_config = aws_config.get('cloudfront', {})
+
+
+        for plugin in cloudfront_config.get('plugins', []):
+            if plugin.get('name', '') == 'tls_protocol':
+                configured_plugin = TLSProtocolPlugin(
+                    plugin.get('config', {})
+                )
+                self.plugins.append(configured_plugin)
+
+    def _collect_all_api_data(self):
+        unique_api_calls = self._unique_api_calls()
+        for provider, services in unique_api_calls.items():
+            for service, api_calls in services.items():
+                for api_call in api_calls:
+                    self._collect_api_data(provider, service, api_call)
+
+
+    def _collect_api_data(self, provider, service, call):
+        if provider == 'aws':
+            if not self.cached_api_data.get('aws'):
+                self.cached_api_data['aws'] = {}
+
+            aws_data = self.cached_api_data['aws']
+            if service == 'cloudfront':
+                if not aws_data.get('cloudfront'):
+                    aws_data['cloudfront'] = {}
+
+                cloudfront_data = aws_data['cloudfront']
+                region = 'aws-global'
+                if not cloudfront_data.get(region, {}):
+                    cloudfront_data[region] = {}
+
+                barrel = CloudFrontBarrel()
+                data = barrel.tap(call)
+                self.cached_api_data[provider][service][region][call] = data
+
+
+    def _unique_api_calls(self):
+        unique_api_calls = {}
+        for plugin in self.plugins:
+            for provider, services in plugin.required_api_calls.items():
+                if provider not in unique_api_calls.keys():
+                    unique_api_calls[provider] = {}
+
+                for service, api_calls in services.items():
+                    if service not in unique_api_calls[provider].keys():
+                        unique_api_calls[provider][service] = set()
+
+                    for api_call in api_calls:
+                        unique_api_calls[provider][service].add(api_call)
+        return unique_api_calls
+
+    def _run_plugins(self):
+        for plugin in self.plugins:
+            results = plugin.run(self.cached_api_data)
+            self._store_results(plugin, results)
+
+    def _store_results(self, plugin, results):
+        provider = plugin.provider
+        service = plugin.service
+        plugin_name = plugin.name
+
+        if not self.scan_data.get(provider):
+            self.scan_data[provider] = {}
+        provider_data = self.scan_data[provider]
+
+        if not provider_data.get(service):
+            provider_data[service] = {}
+
+        service_data = provider_data[service]
+        service_data[plugin_name] = results
+
+
+    def scan(self):
+        self._collect_all_api_data()
+        self._run_plugins()
+        # Return a copy of this so the user does not get direct access to saved scan results
+        return self.scan_data.copy()

--- a/oil/plugins/aws/cloudfront/tls_protocol/__init__.py
+++ b/oil/plugins/aws/cloudfront/tls_protocol/__init__.py
@@ -1,8 +1,29 @@
 class TLSProtocolPlugin():
-    def run(self, data):
-        results = []
 
-        if not data:
+    name = 'tls_protocol'
+    provider = 'aws'
+    service = 'cloudfront'
+
+    required_api_calls = {
+        'aws': {
+            'cloudfront': [
+                'list_distributions'
+            ]
+        }
+    }
+
+    def __init__(self, config={}):
+        """
+        TODO: Set up sensible default config
+        TODO: Set up configurable variables
+        """
+        self.config = config
+
+    def run(self, api_data):
+        results = []
+        distributions = api_data['aws']['cloudfront']['aws-global']['list_distributions']
+
+        if not distributions:
             results.append({
                 'resource': 'None',
                 'region': 'aws-global',
@@ -10,9 +31,9 @@ class TLSProtocolPlugin():
                 'message': 'No distributions found'
             })
 
-        for item in data:
-            resource_arn = item['ARN']
-            protocol_version = item['ViewerCertificate']['MinimumProtocolVersion']
+        for distribution in distributions:
+            resource_arn = distribution['ARN']
+            protocol_version = distribution['ViewerCertificate']['MinimumProtocolVersion']
             if protocol_version == 'SSLv3':
                 severity = 2
                 message = '{} is insecure'.format(protocol_version)

--- a/tests/functional/test_scanning.py
+++ b/tests/functional/test_scanning.py
@@ -15,14 +15,16 @@ from oil import Oil
 
 
 class ScanningTestCase(unittest.TestCase):
-    @unittest.expectedFailure
-    def test_user_can_scan_using_dictionary_configuration(self):
+
+    def test_user_can_scan_with_one_plugin_using_dictionary_configuration(self):
         test_configuration = {
             'aws': {
                 'cloudfront': {
-                    'tls_protocol': {
-
-                    }
+                    'plugins': [
+                        {
+                            'name': 'tls_protocol',
+                        }
+                    ]
                 }
             }
         }

--- a/tests/functional/test_scanning.py
+++ b/tests/functional/test_scanning.py
@@ -15,7 +15,7 @@ from oil import Oil
 
 
 class ScanningTestCase(unittest.TestCase):
-
+    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")
     def test_user_can_scan_with_one_plugin_using_dictionary_configuration(self):
         test_configuration = {
             'aws': {

--- a/tests/integration/test_cloudfront_fetch_and_process_protocols.py
+++ b/tests/integration/test_cloudfront_fetch_and_process_protocols.py
@@ -23,7 +23,17 @@ class CloudfrontFetchAndProcessProtocols(unittest.TestCase):
         client = self.client_mock()
         barrel = CloudFrontBarrel(client)
         data = barrel.list_distributions()
-        results = plugin.run(data)
+        api_data_fixture = {
+            'aws': {
+                'cloudfront': {
+                    'aws-global': {
+                        'list_distributions': data
+                    }
+                }
+            }
+
+        }
+        results = plugin.run(api_data_fixture)
         expected = [
             'resource',
             'region',

--- a/tests/unit/oil/barrels/aws/test_cloudfront.py
+++ b/tests/unit/oil/barrels/aws/test_cloudfront.py
@@ -5,10 +5,10 @@ from tests.fixtures.aws.cloudfront import response_iterator_fixture
 
 
 class CloudFrontBarrelTestCase(unittest.TestCase):
-    def client_mock(self):
+    def client_mock(self, fixture):
         client = MagicMock()
         paginator = MagicMock()
-        response_iterator = response_iterator_fixture
+        response_iterator = fixture
 
         paginator.paginate.return_value = response_iterator
         client.get_paginator.return_value = paginator
@@ -16,7 +16,7 @@ class CloudFrontBarrelTestCase(unittest.TestCase):
         return client
 
     def test_list_distributions_returns_only_distributions(self):
-        client = self.client_mock()
+        client = self.client_mock(response_iterator_fixture)
         barrel = CloudFrontBarrel(client)
 
         results = barrel.list_distributions()
@@ -47,5 +47,38 @@ class CloudFrontBarrelTestCase(unittest.TestCase):
                 }
             }
         ]
+
+        self.assertEqual(results, expected)
+
+    def test_list_distributions_empty_with_no_distributions(self):
+        fixture = [ # Multiple pages of empty
+            {
+                'DistributionList': {
+                    'Items': []
+                }
+            }
+        ]
+        client = self.client_mock(fixture)
+        barrel = CloudFrontBarrel(client)
+
+        results = barrel.list_distributions()
+
+        expected = []
+
+        self.assertEqual(results, expected)
+
+    def test_list_distributions_returns_empty_list_with_no_items_key(self):
+        fixture = [ # Multiple pages of empty
+            {
+                'DistributionList': {
+                }
+            }
+        ]
+        client = self.client_mock(fixture)
+        barrel = CloudFrontBarrel(client)
+
+        results = barrel.list_distributions()
+
+        expected = []
 
         self.assertEqual(results, expected)

--- a/tests/unit/oil/test_oil.py
+++ b/tests/unit/oil/test_oil.py
@@ -1,3 +1,4 @@
 import unittest
 
-
+class OilTestCase(unittest.TestCase):
+    pass


### PR DESCRIPTION
Basic scanning functional test is now passing. Data can be collected and passed into the plugin as expected. The main issue now is mapping API calls to the correct barrel dynamically without having massive if-elif-else blocks for every service/api call. We will address this issue when we hook more plugins into the scanner and can identify some patterns.

Additionally, I added a decorator to the functional test that stops it from running on Travis. This is necessary to avoid lack of AWS credentials blowing it up.