### PR TITLE
Implement InstanceNameTag Plugin to work with Oil

### DIFF
--- a/oil/barrels/aws/ec2.py
+++ b/oil/barrels/aws/ec2.py
@@ -17,7 +17,7 @@ class EC2Barrel():
         'ca-central-1',
         'eu-central-1',
         'eu-west-1',
-        'eu-west-2'
+        'eu-west-2',
         'sa-east-1'
     ])
 
@@ -25,13 +25,22 @@ class EC2Barrel():
         self.clients = clients or self._default_clients()
 
     def _default_clients(self):
+        clients = {}
         for region in self._default_regions:
-            self.clients[region] = boto3.client('ec2', region_name=region)
+            clients[region] = boto3.client('ec2', region_name=region)
+        return clients
+
+    def tap(self, call):
+        if call == 'describe_instances':
+            return self.describe_instances()
+        else:
+            raise RuntimeError('The api call {} is not implemented'.format(call))
 
     def describe_instances(self):
         instances_by_region = {}
         for region, client in self.clients.items():
             paginator = client.get_paginator('describe_instances')
+
             response_iterator = paginator.paginate()
             instances = []
 

--- a/oil/plugins/aws/ec2/instance_name_tag/__init__.py
+++ b/oil/plugins/aws/ec2/instance_name_tag/__init__.py
@@ -1,5 +1,21 @@
 class InstanceNameTagPlugin():
-    def run(self, data):
+
+    name = 'instance_name_tag'
+    service = 'ec2'
+    provider = 'aws'
+
+    required_api_calls = {
+        'aws': {
+            'ec2': [
+                'describe_instances'
+            ]
+        }
+    }
+
+    def __init__(self, config={}):
+        self.config = config
+
+    def run(self, api_data):
         """
         data is of the form: {
           'us-east-1': [
@@ -16,17 +32,16 @@ class InstanceNameTagPlugin():
                or even InStaNcE NAMe)
         """
         results = []
-
-        for region, region_data in data.items():
-            if not region_data:
+        for region, api_calls in api_data['aws']['ec2'].items():
+            instances = api_calls['describe_instances']
+            if not instances:
                 results.append({
                     'resource': 'None',
                     'region': region,
                     'severity': 0,
                     'message': 'No instances found'
                 })
-
-            for instance in region_data:
+            for instance in instances:
                 instance_id = instance['InstanceId']
                 tags = instance.get('Tags', [])
                 name = None

--- a/tests/functional/test_ec2_scanning.py
+++ b/tests/functional/test_ec2_scanning.py
@@ -1,0 +1,29 @@
+# Make sure that Oil implements all necessary EC2 security plugins
+import unittest
+
+from oil import Oil
+
+
+class EC2ScanningTestCase(unittest.TestCase):
+    def test_oil_can_scan_for_name_tag_compliance(self):
+        config = {
+            'aws': {
+                'ec2': {
+                    'plugins': [
+                        {
+                            'name': 'instance_name_tag'
+                        }
+                    ]
+                }
+            }
+        }
+
+        oil = Oil(config)
+        results = oil.scan()
+
+        aws_results = results.get('aws', {})
+        ec2_results = aws_results.get('ec2', {})
+        plugin_results = ec2_results.get('instance_name_tag', [])
+
+        self.assertNotEqual(plugin_results, [])
+

--- a/tests/functional/test_ec2_scanning.py
+++ b/tests/functional/test_ec2_scanning.py
@@ -1,9 +1,11 @@
 # Make sure that Oil implements all necessary EC2 security plugins
 import unittest
+import os
 
 from oil import Oil
 
 
+@unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")
 class EC2ScanningTestCase(unittest.TestCase):
     def test_oil_can_scan_for_name_tag_compliance(self):
         config = {

--- a/tests/functional/test_scanning.py
+++ b/tests/functional/test_scanning.py
@@ -14,8 +14,8 @@ import unittest
 from oil import Oil
 
 
+@unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")
 class ScanningTestCase(unittest.TestCase):
-    @unittest.skipIf("TRAVIS" in os.environ and os.environ["TRAVIS"] == "true", "Skipping this test on Travis CI.")
     def test_user_can_scan_with_one_plugin_using_dictionary_configuration(self):
         test_configuration = {
             'aws': {

--- a/tests/integration/test_ec2_barrel_works_with_plugins.py
+++ b/tests/integration/test_ec2_barrel_works_with_plugins.py
@@ -20,15 +20,26 @@ class EC2BarrelWorksWithPluginsTestCase(unittest.TestCase):
 
     def test_ec2_data_processed_into_desired_results(self):
         plugin = InstanceNameTagPlugin()
-        client = self.client_mock(
-            describe_instances_paginator_with_name_tags
-        )
-        barrel = EC2Barrel(client)
-        instances = barrel.describe_instances()
-        data = {
-            'some-region': instances
+        clients = {
+            'us-east-1': self.client_mock(
+                describe_instances_paginator_with_name_tags
+            )
         }
-        results = plugin.run(data)
+        barrel = EC2Barrel(clients)
+        instances_by_region = barrel.describe_instances()
+
+        # TODO: This object would normally be created by oil
+        api_data = {
+            'aws': {
+                'ec2': {
+                    'us-east-1': {
+                        'describe_instances': instances_by_region['us-east-1']
+                    }
+                }
+            }
+        }
+
+        results = plugin.run(api_data)
         results_keys = list(results[0].keys())
 
         expected = set([

--- a/tests/unit/oil/barrels/aws/test_ec2.py
+++ b/tests/unit/oil/barrels/aws/test_ec2.py
@@ -15,6 +15,18 @@ class EC2BarrelTestCase(unittest.TestCase):
 
         return client
 
+    def test_tap_functions_with_describe_instances(self):
+        clients = {
+            'us-east-1': self.client_mock(
+                boto3_describe_instances_paginator_one_field
+            )
+        }
+        barrel = EC2Barrel(clients)
+        tap_return = barrel.tap('describe_instances')
+        describe_instances_return = barrel.describe_instances()
+
+        self.assertEqual(describe_instances_return, tap_return)
+
     def test_describe_instances_returns_only_instances(self):
         clients = {
             'us-east-1': self.client_mock(

--- a/tests/unit/oil/barrels/aws/test_ec2.py
+++ b/tests/unit/oil/barrels/aws/test_ec2.py
@@ -16,12 +16,15 @@ class EC2BarrelTestCase(unittest.TestCase):
         return client
 
     def test_describe_instances_returns_only_instances(self):
-        client = self.client_mock(
-            boto3_describe_instances_paginator_one_field
-        )
-        barrel = EC2Barrel(client)
+        clients = {
+            'us-east-1': self.client_mock(
+                boto3_describe_instances_paginator_one_field
+            )
+        }
+        barrel = EC2Barrel(clients)
 
         results = barrel.describe_instances()
+        results_from_region = results['us-east-1']
 
         expected = [
             {
@@ -49,5 +52,50 @@ class EC2BarrelTestCase(unittest.TestCase):
                 'InstanceId': 'instance8'
             },
         ]
+
+        self.assertEqual(results_from_region, expected)
+
+    def test_describe_instances_empty_with_no_instances(self):
+        fixture = [ # Multiple pages of empty
+            {
+                'Reservations': [
+                    {
+                        'Instances': []
+                    }
+                ]
+            }
+        ]
+        clients = {
+            'us-east-1': self.client_mock(fixture)
+        }
+        barrel = EC2Barrel(clients)
+
+        results = barrel.describe_instances()
+
+        expected = {
+            'us-east-1': []
+        }
+
+        self.assertEqual(results, expected)
+
+    def test_describe_instances_returns_empty_list_with_no_instances_key(self):
+        fixture = [ # Multiple pages of empty
+            {
+                'Reservations': [
+                    {
+                    }
+                ]
+            }
+        ]
+        clients = {
+            'us-east-1': self.client_mock(fixture)
+        }
+        barrel = EC2Barrel(clients)
+
+        results = barrel.describe_instances()
+
+        expected = {
+            'us-east-1': []
+        }
 
         self.assertEqual(results, expected)

--- a/tests/unit/oil/plugins/aws/ec2/test_instance_name_tag.py
+++ b/tests/unit/oil/plugins/aws/ec2/test_instance_name_tag.py
@@ -3,7 +3,8 @@ import unittest
 from oil.plugins.aws.ec2 import InstanceNameTagPlugin
 
 class InstanceNameTagPluginTestCase(unittest.TestCase):
-    def test_creates_results_with_correct_fields_for_one_instance(self):
+
+    def test_can_be_initialized_and_run_with_no_config(self):
         instance_fixture = {
             'InstanceId': 'theinstance-id',
             'Tags': [
@@ -13,14 +14,49 @@ class InstanceNameTagPluginTestCase(unittest.TestCase):
                 }
             ]
         }
-
         data_fixture = {
-            'us-east-1': [
-                instance_fixture
-            ]
+            'aws': {
+                'ec2': {
+                    'us-east-1': {
+                        'describe_instances': [instance_fixture]
+                    }
+                }
+            }
         }
 
-        plugin = InstanceNameTagPlugin()
+        plugin = InstanceNameTagPlugin({})
+        results = plugin.run(data_fixture)
+        results_keys = list(results[0].keys())
+        expected = [
+            'resource',
+            'severity',
+            'message',
+            'region'
+        ]
+
+        self.assertCountEqual(results_keys, expected)
+
+    def test_can_be_initialized_and_run_with_empty_config(self):
+        instance_fixture = {
+            'InstanceId': 'theinstance-id',
+            'Tags': [
+                {
+                    'Key': 'Name',
+                    'Value': 'An Instance Name'
+                }
+            ]
+        }
+        data_fixture = {
+            'aws': {
+                'ec2': {
+                    'us-east-1': {
+                        'describe_instances': [instance_fixture]
+                    }
+                }
+            }
+        }
+
+        plugin = InstanceNameTagPlugin({})
         results = plugin.run(data_fixture)
         results_keys = list(results[0].keys())
         expected = [
@@ -34,4 +70,47 @@ class InstanceNameTagPluginTestCase(unittest.TestCase):
 
 
 
+
+    def test_creates_results_with_correct_fields_for_multiple_instances(self):
+        instance1_fixture = {
+            'InstanceId': 'theinstance-id1',
+            'Tags': [
+                {
+                    'Key': 'Name',
+                    'Value': 'An Instance Name1'
+                }
+            ]
+        }
+        instance2_fixture = {
+            'InstanceId': 'theinstance-id2',
+            'Tags': [
+                {
+                    'Key': 'Name',
+                    'Value': 'An Instance Name2'
+                }
+            ]
+        }
+
+        instances = [instance1_fixture, instance2_fixture]
+        data_fixture = {
+            'aws': {
+                'ec2': {
+                    'us-east-1': {
+                        'describe_instances': instances
+                    }
+                }
+            }
+        }
+
+        plugin = InstanceNameTagPlugin()
+        results = plugin.run(data_fixture)
+        results_keys = list(results[0].keys())
+        expected = [
+            'resource',
+            'severity',
+            'message',
+            'region'
+        ]
+
+        self.assertCountEqual(results_keys, expected)
 

--- a/tests/unit/oil/test_oil.py
+++ b/tests/unit/oil/test_oil.py
@@ -9,6 +9,10 @@ class OilTestCase(unittest.TestCase):
         providers = oil.providers
         self.assertEqual(providers, [])
 
+    def test_services_throws_error_with_unsupported_provider(self):
+        oil = Oil()
+        with self.assertRaises(RuntimeError):
+            services = oil.services('unsupported_provider')
 
     def test_loading_plugins_throws_error_if_provider_is_not_registered(self):
         config = {

--- a/tests/unit/oil/test_oil.py
+++ b/tests/unit/oil/test_oil.py
@@ -1,4 +1,51 @@
 import unittest
 
+from oil import Oil
+
 class OilTestCase(unittest.TestCase):
-    pass
+
+    def test_providers_is_empty_with_no_plugins(self):
+        oil = Oil()
+        providers = oil.providers
+        self.assertEqual(providers, [])
+
+
+    def test_loading_plugins_throws_error_if_provider_is_not_registered(self):
+        config = {
+            'unsupported_provider': {
+                'this': {
+                    'plugins': []
+                }
+            }
+        }
+
+        with self.assertRaises(RuntimeError):
+            oil = Oil(config)
+
+    def test_loading_plugins_throws_error_if_service_is_not_registered(self):
+        config = {
+            'aws': {
+                'unsupported_service': {
+                    'plugins': []
+                }
+            }
+        }
+
+        with self.assertRaises(RuntimeError):
+            oil = Oil(config)
+
+    def test_loading_plugins_throws_error_if_plugin_is_not_registered(self):
+        config = {
+            'aws': {
+                'cloudfront': {
+                    'plugins': [
+                        {
+                            'name': 'fake_plugin'
+                        }
+                    ]
+                }
+            }
+        }
+
+        with self.assertRaises(RuntimeError):
+            oil = Oil(config)


### PR DESCRIPTION
Add logic in the Oil class to get the InstanceNameTagPlugin to be configurable in the dict object passed to Oil. Update InstanceNameTagPlugin and EC2Barrel to work for mutliple regions.