### PR TITLE
Add coverage dev dependancy and update travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ install:
   - pip install -r requirements.dev.txt
 
 script:
-  - invoke test --no-functional
   - coverage run --source=oil -m unittest discover -s tests
   - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,5 @@ install:
 
 script:
   - invoke test --no-functional
+  - coverage run --source=oil -m unittest tests
+  - coverage report

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 
 script:
   - invoke test --no-functional
-  - coverage run --source=oil -m unittest tests
+  - coverage run --source=oil -m unittest discover -s tests
   - coverage report

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,3 @@
 invoke==0.21.0
 pytest==3.2.3
+coverage==4.4.2


### PR DESCRIPTION
If we want an HTML page to be built that shows our coverage, I will need the request I made allowing the coveralls integration here. Link for reference: https://coveralls.io/