### PR TITLE
Implement describe security groups and get ec2 barrel to full coverage

### DIFF
--- a/oil/barrels/aws/ec2.py
+++ b/oil/barrels/aws/ec2.py
@@ -33,6 +33,8 @@ class EC2Barrel():
     def tap(self, call):
         if call == 'describe_instances':
             return self.describe_instances()
+        if call == 'describe_security_groups':
+            return self.describe_security_groups()
         else:
             raise RuntimeError('The api call {} is not implemented'.format(call))
 
@@ -51,3 +53,18 @@ class EC2Barrel():
             instances_by_region[region] = instances
 
         return instances_by_region
+
+    def describe_security_groups(self):
+        security_groups_by_region = {}
+        for region, client in self.clients.items():
+            paginator = client.get_paginator('describe_security_groups')
+
+            response_iterator = paginator.paginate()
+            groups = []
+
+            for page in response_iterator:
+                groups.extend(page.get('SecurityGroups', []))
+
+            security_groups_by_region[region] = groups
+
+        return security_groups_by_region

--- a/tests/unit/oil/barrels/aws/test_ec2.py
+++ b/tests/unit/oil/barrels/aws/test_ec2.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from oil.barrels.aws import EC2Barrel
 from tests.fixtures.aws.ec2 import boto3_describe_instances_paginator_one_field
 
@@ -15,6 +15,34 @@ class EC2BarrelTestCase(unittest.TestCase):
 
         return client
 
+    def test_has_correct_default_regions(self):
+        default_regions = set([
+            'us-east-2',
+            'us-east-1',
+            'us-west-1',
+            'us-west-2',
+            'ap-south-1',
+            'ap-northeast-1',
+            'ap-northeast-2',
+            'ap-southeast-1',
+            'ap-southeast-2',
+            'ca-central-1',
+            'eu-central-1',
+            'eu-west-1',
+            'eu-west-2',
+            'sa-east-1'
+        ])
+        barrel = EC2Barrel([])
+        self.assertEqual(default_regions, barrel._default_regions)
+
+    @patch("boto3.client")
+    def test_default_clients(self, mock_client):
+        mock_client.return_value = MagicMock()
+        barrel = EC2Barrel()
+
+        for region, client in barrel.clients.items():
+            self.assertIn(region, barrel._default_regions)
+
     def test_tap_functions_with_describe_instances(self):
         clients = {
             'us-east-1': self.client_mock(
@@ -26,6 +54,24 @@ class EC2BarrelTestCase(unittest.TestCase):
         describe_instances_return = barrel.describe_instances()
 
         self.assertEqual(describe_instances_return, tap_return)
+
+    def test_tap_functions_with_describe_security_groups(self):
+        clients = {
+            'us-east-1': self.client_mock(
+                boto3_describe_instances_paginator_one_field
+            )
+        }
+        barrel = EC2Barrel(clients)
+        tap_return = barrel.tap('describe_security_groups')
+        describe_security_groups_return = barrel.describe_security_groups()
+
+        self.assertEqual(describe_security_groups_return, tap_return)
+
+    def test_tap_throws_error_with_unsupported_call(self):
+        barrel = EC2Barrel([])
+
+        with self.assertRaises(RuntimeError):
+            tap_return = barrel.tap('unsupported_call')
 
     def test_describe_instances_returns_only_instances(self):
         clients = {
@@ -105,6 +151,93 @@ class EC2BarrelTestCase(unittest.TestCase):
         barrel = EC2Barrel(clients)
 
         results = barrel.describe_instances()
+
+        expected = {
+            'us-east-1': []
+        }
+
+        self.assertEqual(results, expected)
+
+    def test_describe_security_groups_returns_only_security_groups(self):
+        fixture = [
+            {
+                'SecurityGroups': [
+                    {
+                        'GroupName': 'group1'
+                    },
+                    {
+                        'GroupName': 'group2'
+                    }
+                ]
+            },
+            {
+                'SecurityGroups': [
+                    {
+                        'GroupName': 'group3'
+                    },
+                    {
+                        'GroupName': 'group4'
+                    },
+                ]
+            }
+        ]
+        clients = {
+            'us-east-1': self.client_mock(fixture)
+        }
+        barrel = EC2Barrel(clients)
+
+        results = barrel.describe_security_groups()
+        expected = {
+            'us-east-1': [
+                {
+                    'GroupName': 'group1'
+                },
+                {
+                    'GroupName': 'group2'
+                },
+                {
+                    'GroupName': 'group3'
+                },
+                {
+                    'GroupName': 'group4'
+                }
+            ]
+        }
+
+        self.assertEqual(results, expected)
+
+    def test_describe_security_groups_empty(self):
+        fixture = [
+            {
+                'SecurityGroups': [
+                ]
+            }
+        ]
+        clients = {
+            'us-east-1': self.client_mock(fixture)
+        }
+        barrel = EC2Barrel(clients)
+
+        results = barrel.describe_security_groups()
+
+        expected = {
+            'us-east-1': []
+        }
+
+        self.assertEqual(results, expected)
+
+    def test_describe_security_groups_returns_empty_list_with_missing_key(self):
+        fixture = [
+            {
+                # Security groups key should be here
+            }
+        ]
+        clients = {
+            'us-east-1': self.client_mock(fixture)
+        }
+        barrel = EC2Barrel(clients)
+
+        results = barrel.describe_security_groups()
 
         expected = {
             'us-east-1': []


### PR DESCRIPTION
Used coverage tool to analyze code coverage for EC2 barrel and implemented tests that get the code to 100% coverage. We have some additional tests in cloudfront barrel/plugins and the ec2 instance name tag plugin to attain full coverage. The Oil class also needs some tests.