### PR TITLE
Correctly obtain viewer policy from distribution

### DIFF
--- a/oil/plugins/aws/cloudfront/https/__init__.py
+++ b/oil/plugins/aws/cloudfront/https/__init__.py
@@ -32,7 +32,8 @@ class HTTPSPlugin():
 
         for distribution in distributions:
             resource_arn = distribution['ARN']
-            viewer_policy = distribution.get('ViewerProtocolPolicy')
+            cache_behavior = distribution.get('DefaultCacheBehavior', {})
+            viewer_policy = cache_behavior.get('ViewerProtocolPolicy', '')
 
             if not viewer_policy:
                 severity = 3

--- a/tests/unit/oil/plugins/aws/cloudfront/test_https.py
+++ b/tests/unit/oil/plugins/aws/cloudfront/test_https.py
@@ -12,7 +12,6 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'arn1',
-                                'ViewerProtocolPolicy': 'allow-all'
                             }
                         ]
                     }
@@ -40,7 +39,6 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'arn1',
-                                'ViewerProtocolPolicy': 'allow-all'
                             }
                         ]
                     }
@@ -156,7 +154,9 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'anarn',
-                                'ViewerProtocolPolicy': 'unsupported-policy'
+                                'DefaultCacheBehavior': {
+                                    'ViewerProtocolPolicy': 'unsupported-policy'
+                                }
                             }
                         ]
                     }
@@ -183,7 +183,9 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'anarn',
-                                'ViewerProtocolPolicy': 'allow-all'
+                                'DefaultCacheBehavior': {
+                                    'ViewerProtocolPolicy': 'allow-all'
+                                }
                             }
                         ]
                     }
@@ -210,7 +212,9 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'anarn',
-                                'ViewerProtocolPolicy': 'redirect-to-https'
+                                'DefaultCacheBehavior': {
+                                    'ViewerProtocolPolicy': 'redirect-to-https'
+                                }
                             }
                         ]
                     }
@@ -240,7 +244,9 @@ class HTTPSPluginTestCase(unittest.TestCase):
                         'list_distributions': [
                             {
                                 'ARN': 'anarn',
-                                'ViewerProtocolPolicy': 'https-only'
+                                'DefaultCacheBehavior': {
+                                    'ViewerProtocolPolicy': 'https-only'
+                                }
                             }
                         ]
                     }


### PR DESCRIPTION
The code was missing the nested dict DefaultCacheDict, which holds the ViewerProtocolPolicy key. I adjusted the code and unit tests.