### PR TITLE
Create basic installation procedure in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,12 @@ This project is based on some specific design goals:
 - Results are returned in a simple to navigate Python dictionary
 - Support for Azure and Google Cloud
 
+Build
+-----
+Download the repo and install with::
+
+  pip install -e .
+
 Development Usage
 -----------------
 Run the default scan and print to console::

--- a/oil/__init__.py
+++ b/oil/__init__.py
@@ -1,1 +1,2 @@
 from oil.oil import Oil
+from oil.utils import version

--- a/oil/oil.py
+++ b/oil/oil.py
@@ -3,6 +3,7 @@ from oil.plugins.aws.ec2 import *
 from oil.plugins.aws.iam import *
 from oil.barrels.aws import *
 
+
 class Oil():
     default_config = {
         'aws': {

--- a/oil/utils.py
+++ b/oil/utils.py
@@ -1,5 +1,11 @@
 import arrow
 
+VERSION = '0.0.1'
+
 
 def days_ago(dt_string):
     return (arrow.utcnow() - arrow.get(dt_string)).days
+
+
+def version():
+    return VERSION

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+version = __import__('oil').version()
+
+# For future package excludes, such as 'oil.config'
+EXCLUDES = []
+
+setup(
+    name="oil",
+    version=version,
+    url="https://github.com/coolfriends/oil",
+    author="Cabal",
+    description='An extensible framework for auditing cloud resources.',
+    license='MIT',
+    packages=find_packages(exclude=EXCLUDES),
+    install_requires=[
+        'boto3',
+        'arrow',
+    ],
+)


### PR DESCRIPTION
oil can now be installed by downloading the project and installing with `pip install -e .`. We can move toward deploying to PyPI later.