### PR TITLE
Issue 70

### DIFF
--- a/oil/__init__.py
+++ b/oil/__init__.py
@@ -1,2 +1,3 @@
+__version__ = '0.1'
+
 from oil.oil import Oil
-from oil.utils import version

--- a/oil/__init__.py
+++ b/oil/__init__.py
@@ -1,3 +1,5 @@
 __version__ = '0.1'
+# NOTE: Don't bump the version number until we are deployed to PyPI
+
 
 from oil.oil import Oil

--- a/oil/utils.py
+++ b/oil/utils.py
@@ -1,11 +1,5 @@
 import arrow
 
-VERSION = '0.0.1'
-
 
 def days_ago(dt_string):
     return (arrow.utcnow() - arrow.get(dt_string)).days
-
-
-def version():
-    return VERSION

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
+import re
 from setuptools import setup, find_packages
 
-version = __import__('oil').version()
+# get the version as a string, assuming it's at the top of oil/__init__.py
+version_reg = re.compile('\d.\d')
+with open('oil/__init__.py') as f:
+    match = version_reg.search(f.readline())
+    _version = match[0]
 
 # For future package excludes, such as 'oil.config'
 EXCLUDES = []
 
 setup(
     name="oil",
-    version=version,
+    version=_version,
     url="https://github.com/coolfriends/oil",
     author="Cabal",
     description='An extensible framework for auditing cloud resources.',


### PR DESCRIPTION
Fixes #70 

Before, building with setup.py would throw an error because the arrow package gets imported in the oil/__init__.py file. I changed the way the version is obtained to reading the file and grabbing the number with a regex from the first line.