### PR TITLE
Create kwarg validation and add support for aws kwargs

### DIFF
--- a/oil/oil.py
+++ b/oil/oil.py
@@ -80,16 +80,33 @@ class Oil():
         RDSBarrel,
     ]
 
-    def __init__(self, config={}):
+    _valid_kwargs = set([
+        'aws_access_key_id',
+        'aws_secret_access_key',
+        'session_token'
+    ])
+
+    def __init__(self, config={}, **kwargs):
         """
         TODO: Create sensible default configuration
         """
-        self.config = config or self.default_config;
+        self._validate_kwargs(**kwargs)
+        self.config = config or self.default_config
         self.cached_api_data = {}
         self.scan_data = {}
         self.plugins = []
         self._load_plugins()
         self._load_barrels()
+        self.aws_access_key_id = kwargs.get('aws_access_key_id')
+        self.aws_secret_access_key = kwargs.get('aws_secret_access_key')
+        self.session_token = kwargs.get('session_token')
+
+    def _validate_kwargs(self, **kwargs):
+        for k, v in kwargs.items():
+            if k not in self._valid_kwargs:
+                raise RuntimeError(
+                    'Received invalid kwarg: {}'.format(k)
+                )
 
     def scan(self):
         self._collect_all_api_data()

--- a/tests/unit/oil/test_oil.py
+++ b/tests/unit/oil/test_oil.py
@@ -7,6 +7,34 @@ from oil.barrels.aws import CloudFrontBarrel
 
 class OilTestCase(unittest.TestCase):
 
+    def test_can_take_sts_credentials(self):
+        oil = Oil(
+            aws_access_key_id='my_id',
+            aws_secret_access_key='my_key',
+            session_token='my_token',
+        )
+        self.assertEqual(oil.aws_access_key_id, 'my_id')
+        self.assertEqual(oil.aws_secret_access_key, 'my_key')
+        self.assertEqual(oil.session_token, 'my_token')
+
+    def test_validates_good_kwargs(self):
+        valid_args = {
+            'aws_access_key_id': 'my_id',
+            'aws_secret_access_key': 'my_key',
+            'session_token': 'session_token',
+        }
+        oil = Oil()
+        oil._validate_kwargs(**valid_args)
+
+    def test_oil_throws_error_with_bad_kwargs(self):
+        with self.assertRaises(RuntimeError):
+            Oil(bad_arg='my_bad_arg')
+
+    def test_validate_kwargs_throws_error_with_bad_kwargs(self):
+        oil = Oil()
+        with self.assertRaises(RuntimeError):
+            oil._validate_kwargs(bad_arg='my_bad_arg')
+
     def test_providers_are_default_with_no_config_passed(self):
         oil = Oil()
         providers = oil.providers


### PR DESCRIPTION
Implemented kwarg validation and added support for aws credentials. These credentials are not currently used for anything... they will either need to be passed directly into barrels, or we can create an boto3 session.Session instance in oil and send it to the barrels. Alternatively, we could pass oil into the plugin like so:
```python
from oil import Oil
from oil.barrels.aws import CloudFrontBarrel
scanner = Oil()
scanner.register_barrel(CloudFrontBarrel)

# Oil.register_barrel will end up doing this somewhere...
CloudFrontBarrel(self)
```