### PR TITLE
Add region overloading to barrels

### DIFF
--- a/oil/barrels/aws/cloudfront.py
+++ b/oil/barrels/aws/cloudfront.py
@@ -2,7 +2,7 @@ from oil.barrels.barrel import Barrel
 
 
 class CloudFrontBarrel(Barrel):
-    _default_regions = set([
+    supported_regions = set([
         'aws-global'
     ])
     provider = 'aws'

--- a/oil/barrels/aws/ec2.py
+++ b/oil/barrels/aws/ec2.py
@@ -6,7 +6,7 @@ class EC2Barrel(Barrel):
     TODO: Extend barrel to work for multiple regions by leveraging
     multiple clients
     """
-    _default_regions = set([
+    supported_regions = set([
         'us-east-2',
         'us-east-1',
         'us-west-1',

--- a/oil/barrels/aws/iam.py
+++ b/oil/barrels/aws/iam.py
@@ -2,7 +2,7 @@ from oil.barrels.barrel import Barrel
 
 
 class IAMBarrel(Barrel):
-    _default_regions = set([
+    supported_regions = set([
         'aws-global'
     ])
     provider = 'aws'

--- a/oil/barrels/aws/rds.py
+++ b/oil/barrels/aws/rds.py
@@ -2,7 +2,7 @@ from oil.barrels.barrel import Barrel
 
 
 class RDSBarrel(Barrel):
-    _default_regions = set([
+    supported_regions = set([
         'us-east-2',
         'us-east-1',
         'us-west-1',

--- a/oil/barrels/barrel.py
+++ b/oil/barrels/barrel.py
@@ -2,7 +2,7 @@ import boto3
 
 
 class Barrel():
-    _default_regions = set()
+    supported_regions = set()
     provider = None
     service = None
     tap_calls = set()
@@ -15,11 +15,14 @@ class Barrel():
             aws_secret_access_key=kwargs.get('aws_secret_access_key'),
             aws_session_token=kwargs.get('session_token'),
         )
-        self.clients = kwargs.get('clients', self._default_clients())
+        self.regions = kwargs.get('regions', self.supported_regions)
+        self.clients = kwargs.get('clients')
+        if self.clients is None:
+            self.clients = self._make_clients()
 
-    def _default_clients(self):
+    def _make_clients(self):
         clients = {}
-        for region in self._default_regions:
+        for region in self.regions:
             clients[region] = self.session.client(
                 self.service,
                 region_name=region,

--- a/tests/unit/oil/barrels/aws/test_cloudfront.py
+++ b/tests/unit/oil/barrels/aws/test_cloudfront.py
@@ -15,12 +15,12 @@ class CloudFrontBarrelTestCase(unittest.TestCase):
 
         return client
 
-    def test_has_correct_default_regions(self):
-        default_regions = set([
+    def test_has_correct_supported_regions(self):
+        supported_regions = set([
             'aws-global'
         ])
         barrel = CloudFrontBarrel({}, clients={})
-        self.assertEqual(default_regions, barrel._default_regions)
+        self.assertEqual(supported_regions, barrel.supported_regions)
 
     @patch("boto3.client")
     def test_default_clients(self, mock_client):
@@ -28,7 +28,7 @@ class CloudFrontBarrelTestCase(unittest.TestCase):
         barrel = CloudFrontBarrel({})
 
         for region, client in barrel.clients.items():
-            self.assertIn(region, barrel._default_regions)
+            self.assertIn(region, barrel.supported_regions)
 
     def test_tap_functions_with_list_distributions(self):
         fixture = [

--- a/tests/unit/oil/barrels/aws/test_ec2.py
+++ b/tests/unit/oil/barrels/aws/test_ec2.py
@@ -15,8 +15,8 @@ class EC2BarrelTestCase(unittest.TestCase):
 
         return client
 
-    def test_has_correct_default_regions(self):
-        default_regions = set([
+    def test_has_correct_supported_regions(self):
+        supported_regions = set([
             'us-east-2',
             'us-east-1',
             'us-west-1',
@@ -33,7 +33,7 @@ class EC2BarrelTestCase(unittest.TestCase):
             'sa-east-1'
         ])
         barrel = EC2Barrel({})
-        self.assertEqual(default_regions, barrel._default_regions)
+        self.assertEqual(supported_regions, barrel.supported_regions)
 
     @patch("boto3.client")
     def test_default_clients(self, mock_client):
@@ -41,7 +41,7 @@ class EC2BarrelTestCase(unittest.TestCase):
         barrel = EC2Barrel({})
 
         for region, client in barrel.clients.items():
-            self.assertIn(region, barrel._default_regions)
+            self.assertIn(region, barrel.supported_regions)
 
     def test_tap_functions_with_describe_instances(self):
         clients = {

--- a/tests/unit/oil/barrels/aws/test_iam.py
+++ b/tests/unit/oil/barrels/aws/test_iam.py
@@ -37,12 +37,12 @@ class IAMBarrelTestCase(unittest.TestCase):
 
         return client
 
-    def test_has_correct_default_regions(self):
-        default_regions = set([
+    def test_has_correct_supported_regions(self):
+        supported_regions = set([
             'aws-global'
         ])
         barrel = IAMBarrel({})
-        self.assertEqual(default_regions, barrel._default_regions)
+        self.assertEqual(supported_regions, barrel.supported_regions)
 
     @patch("boto3.client")
     def test_default_clients(self, mock_client):
@@ -50,7 +50,7 @@ class IAMBarrelTestCase(unittest.TestCase):
         barrel = IAMBarrel({})
 
         for region, client in barrel.clients.items():
-            self.assertIn(region, barrel._default_regions)
+            self.assertIn(region, barrel.supported_regions)
 
     def test_tap_functions_with_get_credential_report(self):
         client = MagicMock()

--- a/tests/unit/oil/barrels/aws/test_rds.py
+++ b/tests/unit/oil/barrels/aws/test_rds.py
@@ -14,8 +14,8 @@ class RDSBarrelTestCase(unittest.TestCase):
 
         return client
 
-    def test_has_correct_default_regions(self):
-        default_regions = set([
+    def test_has_correct_supported_regions(self):
+        supported_regions = set([
             'us-east-2',
             'us-east-1',
             'us-west-1',
@@ -32,15 +32,15 @@ class RDSBarrelTestCase(unittest.TestCase):
             'sa-east-1',
         ])
         barrel = RDSBarrel({})
-        self.assertEqual(default_regions, barrel._default_regions)
+        self.assertEqual(supported_regions, barrel.supported_regions)
 
     @patch("boto3.client")
-    def test_default_clients(self, mock_client):
+    def test_supported_clients(self, mock_client):
         mock_client.return_value = MagicMock()
         barrel = RDSBarrel({})
 
         for region, client in barrel.clients.items():
-            self.assertIn(region, barrel._default_regions)
+            self.assertIn(region, barrel.supported_regions)
 
     def test_tap_functions_with_describe_db_instances(self):
         clients = {

--- a/tests/unit/oil/test_barrel.py
+++ b/tests/unit/oil/test_barrel.py
@@ -1,0 +1,16 @@
+import unittest
+
+from oil.barrels.barrel import Barrel
+
+
+class BarrelTestCase(unittest.TestCase):
+
+    def test_regions_can_be_configured(self):
+        my_regions = [
+            'my-region-1',
+            'my-region-2'
+        ]
+        mock_oil = {}
+        mock_clients = {}
+        barrel = Barrel(mock_oil, regions=my_regions, clients=mock_clients)
+        self.assertEqual(barrel.regions, my_regions)


### PR DESCRIPTION
Barrels can now be configured with a regions kwarg that overloads the default regions (now called supported regions).

```python
barrel = oil.register_barrel(CloudFrontBarrel, config={
    'regions': [
        'my',
        'fun',
        'regions',
    ]
}
```